### PR TITLE
Add Browser page and nav link

### DIFF
--- a/src/lib/i18n/locales/ar-BH/translation.json
+++ b/src/lib/i18n/locales/ar-BH/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "ملاحظة: إذا قمت بتعيين الحد الأدنى من النقاط، فلن يؤدي البحث إلا إلى إرجاع المستندات التي لها نقاط أكبر من أو تساوي الحد الأدنى من النقاط.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "إشعارات",

--- a/src/lib/i18n/locales/bg-BG/translation.json
+++ b/src/lib/i18n/locales/bg-BG/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Забележка: Ако зададете минимален резултат, търсенето ще върне само документи с резултат, по-голям или равен на минималния резултат.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Десктоп Известия",

--- a/src/lib/i18n/locales/bn-BD/translation.json
+++ b/src/lib/i18n/locales/bn-BD/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "দ্রষ্টব্য: আপনি যদি ন্যূনতম স্কোর সেট করেন তবে অনুসন্ধানটি কেবলমাত্র ন্যূনতম স্কোরের চেয়ে বেশি বা সমান স্কোর সহ নথিগুলি ফেরত দেবে।",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "নোটিফিকেশনসমূহ",

--- a/src/lib/i18n/locales/ca-ES/translation.json
+++ b/src/lib/i18n/locales/ca-ES/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "No ajuda",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Nota: Si s'estableix una puntuació mínima, la cerca només retornarà documents amb una puntuació major o igual a la puntuació mínima.",
 	"Notes": "Notes",
+        "Browser": "",
 	"Notification Sound": "So de la notificació",
 	"Notification Webhook": "Webhook de la notificació",
 	"Notifications": "Notificacions",

--- a/src/lib/i18n/locales/ceb-PH/translation.json
+++ b/src/lib/i18n/locales/ceb-PH/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Mga pahibalo sa desktop",

--- a/src/lib/i18n/locales/cs-CZ/translation.json
+++ b/src/lib/i18n/locales/cs-CZ/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Nepomocné",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Poznámka: Pokud nastavíte minimální skóre, vyhledávání vrátí pouze dokumenty s hodnocením, které je větší nebo rovno zadanému minimálnímu skóre.",
 	"Notes": "Poznámky",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Oznámení",

--- a/src/lib/i18n/locales/da-DK/translation.json
+++ b/src/lib/i18n/locales/da-DK/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Bemærk: Hvis du angiver en minimumscore, returnerer søgningen kun dokumenter med en score, der er større end eller lig med minimumscoren.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Notifikationer",

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Nich hilfreich",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Hinweis: Wenn Sie eine Mindestpunktzahl festlegen, werden in der Suche nur Dokumente mit einer Punktzahl größer oder gleich der Mindestpunktzahl zurückgegeben.",
 	"Notes": "Notizen",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Benachrichtigungen",

--- a/src/lib/i18n/locales/dg-DG/translation.json
+++ b/src/lib/i18n/locales/dg-DG/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Notifications",

--- a/src/lib/i18n/locales/el-GR/translation.json
+++ b/src/lib/i18n/locales/el-GR/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Δεν είναι χρήσιμο",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Σημείωση: Αν ορίσετε ένα ελάχιστο score, η αναζήτηση θα επιστρέψει μόνο έγγραφα με score μεγαλύτερο ή ίσο με το ελάχιστο score.",
 	"Notes": "Σημειώσεις",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Ειδοποιήσεις",

--- a/src/lib/i18n/locales/en-GB/translation.json
+++ b/src/lib/i18n/locales/en-GB/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "",

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "",

--- a/src/lib/i18n/locales/es-ES/translation.json
+++ b/src/lib/i18n/locales/es-ES/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Nota: Si estableces una puntuación mínima, la búsqueda sólo devolverá documentos con una puntuación mayor o igual a la puntuación mínima.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Notificaciones",

--- a/src/lib/i18n/locales/eu-ES/translation.json
+++ b/src/lib/i18n/locales/eu-ES/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Ez da lagungarria",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Oharra: Gutxieneko puntuazio bat ezartzen baduzu, bilaketak gutxieneko puntuazioa baino handiagoa edo berdina duten dokumentuak soilik itzuliko ditu.",
 	"Notes": "Oharrak",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Jakinarazpenak",

--- a/src/lib/i18n/locales/fa-IR/translation.json
+++ b/src/lib/i18n/locales/fa-IR/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "توجه: اگر حداقل نمره را تعیین کنید، جستجو تنها اسنادی را با نمره بیشتر یا برابر با حداقل نمره باز می گرداند.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "اعلان",

--- a/src/lib/i18n/locales/fi-FI/translation.json
+++ b/src/lib/i18n/locales/fi-FI/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Ei hyödyllinen",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Huomautus: Jos asetat vähimmäispistemäärän, haku palauttaa vain sellaiset asiakirjat, joiden pistemäärä on vähintään vähimmäismäärä.",
 	"Notes": "Muistiinpanot",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Ilmoitukset",

--- a/src/lib/i18n/locales/fr-CA/translation.json
+++ b/src/lib/i18n/locales/fr-CA/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Note : Si vous définissez un score minimum, seuls les documents ayant un score supérieur ou égal à ce score minimum seront retournés par la recherche.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Notifications",

--- a/src/lib/i18n/locales/fr-FR/translation.json
+++ b/src/lib/i18n/locales/fr-FR/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Pas utile",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Note : Si vous définissez un score minimum, seuls les documents ayant un score supérieur ou égal à ce score minimum seront retournés par la recherche.",
 	"Notes": "Notes",
+        "Browser": "",
 	"Notification Sound": "Son de notification",
 	"Notification Webhook": "Webhook de notification",
 	"Notifications": "Notifications",

--- a/src/lib/i18n/locales/he-IL/translation.json
+++ b/src/lib/i18n/locales/he-IL/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "הערה: אם תקבע ציון מינימלי, החיפוש יחזיר רק מסמכים עם ציון שגבוה או שווה לציון המינימלי.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "התראות",

--- a/src/lib/i18n/locales/hi-IN/translation.json
+++ b/src/lib/i18n/locales/hi-IN/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "ध्यान दें: यदि आप न्यूनतम स्कोर निर्धारित करते हैं, तो खोज केवल न्यूनतम स्कोर से अधिक या उसके बराबर स्कोर वाले दस्तावेज़ वापस लाएगी।",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "सूचनाएं",

--- a/src/lib/i18n/locales/hr-HR/translation.json
+++ b/src/lib/i18n/locales/hr-HR/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Napomena: Ako postavite minimalnu ocjenu, pretraga će vratiti samo dokumente s ocjenom većom ili jednakom minimalnoj ocjeni.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Obavijesti",

--- a/src/lib/i18n/locales/hu-HU/translation.json
+++ b/src/lib/i18n/locales/hu-HU/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Nem segítőkész",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Megjegyzés: Ha minimum pontszámot állít be, a keresés csak olyan dokumentumokat ad vissza, amelyek pontszáma nagyobb vagy egyenlő a minimum pontszámmal.",
 	"Notes": "Jegyzetek",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Értesítések",

--- a/src/lib/i18n/locales/id-ID/translation.json
+++ b/src/lib/i18n/locales/id-ID/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Catatan: Jika Anda menetapkan skor minimum, pencarian hanya akan mengembalikan dokumen dengan skor yang lebih besar atau sama dengan skor minimum.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Pemberitahuan",

--- a/src/lib/i18n/locales/ie-GA/translation.json
+++ b/src/lib/i18n/locales/ie-GA/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Gan a bheith cabhrach",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Nóta: Má shocraíonn tú íosscór, ní thabharfaidh an cuardach ach doiciméid a bhfuil scór níos mó ná nó cothrom leis an scór íosta ar ais.",
 	"Notes": "Nótaí",
+        "Browser": "",
 	"Notification Sound": "Fuaim Fógra",
 	"Notification Webhook": "Fógra Webook",
 	"Notifications": "Fógraí",

--- a/src/lib/i18n/locales/it-IT/translation.json
+++ b/src/lib/i18n/locales/it-IT/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Nota: se imposti un punteggio minimo, la ricerca restituirà solo i documenti con un punteggio maggiore o uguale al punteggio minimo.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Notifiche desktop",

--- a/src/lib/i18n/locales/ja-JP/translation.json
+++ b/src/lib/i18n/locales/ja-JP/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "注意：最小スコアを設定した場合、検索は最小スコア以上のスコアを持つドキュメントのみを返します。",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "通知音",
 	"Notification Webhook": "",
 	"Notifications": "デスクトップ通知",

--- a/src/lib/i18n/locales/ka-GE/translation.json
+++ b/src/lib/i18n/locales/ka-GE/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "შენიშვნა: თუ თქვენ დააყენებთ მინიმალურ ქულას, ძებნა დააბრუნებს მხოლოდ დოკუმენტებს მინიმალური ქულის მეტი ან ტოლი ქულით.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "შეტყობინება",

--- a/src/lib/i18n/locales/ko-KR/translation.json
+++ b/src/lib/i18n/locales/ko-KR/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "도움이 되지않음",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "참고: 최소 점수를 설정하면, 검색 결과로 최소 점수 이상의 점수를 가진 문서만 반환합니다.",
 	"Notes": "노트",
+        "Browser": "",
 	"Notification Sound": "알림 소리",
 	"Notification Webhook": "알림 웹훅",
 	"Notifications": "알림",

--- a/src/lib/i18n/locales/lt-LT/translation.json
+++ b/src/lib/i18n/locales/lt-LT/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Jei turite minimalų įvertį, paieška gražins tik tą informaciją, kuri viršyje šį įvertį",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Pranešimai",

--- a/src/lib/i18n/locales/ms-MY/translation.json
+++ b/src/lib/i18n/locales/ms-MY/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Nota: Jika anda menetapkan skor minimum, carian hanya akan mengembalikan dokumen dengan skor lebih besar daripada atau sama dengan skor minimum.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Pemberitahuan",

--- a/src/lib/i18n/locales/nb-NO/translation.json
+++ b/src/lib/i18n/locales/nb-NO/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Ikke nyttig",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Merk: Hvis du setter en minimumspoengsum, returnerer søket kun dokumenter med en poengsum som er større enn eller lik minimumspoengsummen.",
 	"Notes": "Notater",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Varsler",

--- a/src/lib/i18n/locales/nl-NL/translation.json
+++ b/src/lib/i18n/locales/nl-NL/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Niet nuttig",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Opmerking: Als je een minimumscore instelt, levert de zoekopdracht alleen documenten op met een score groter dan of gelijk aan de minimumscore.",
 	"Notes": "Aantekeningen",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Notificaties",

--- a/src/lib/i18n/locales/pa-IN/translation.json
+++ b/src/lib/i18n/locales/pa-IN/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "ਨੋਟ: ਜੇ ਤੁਸੀਂ ਘੱਟੋ-ਘੱਟ ਸਕੋਰ ਸੈੱਟ ਕਰਦੇ ਹੋ, ਤਾਂ ਖੋਜ ਸਿਰਫ਼ ਉਹੀ ਡਾਕੂਮੈਂਟ ਵਾਪਸ ਕਰੇਗੀ ਜਿਨ੍ਹਾਂ ਦਾ ਸਕੋਰ ਘੱਟੋ-ਘੱਟ ਸਕੋਰ ਦੇ ਬਰਾਬਰ ਜਾਂ ਵੱਧ ਹੋਵੇ।",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "ਸੂਚਨਾਵਾਂ",

--- a/src/lib/i18n/locales/pl-PL/translation.json
+++ b/src/lib/i18n/locales/pl-PL/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Uwaga: Jeśli ustawisz minimalny wynik, szukanie zwróci jedynie dokumenty z wynikiem większym lub równym minimalnemu.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Powiadomienia",

--- a/src/lib/i18n/locales/pt-BR/translation.json
+++ b/src/lib/i18n/locales/pt-BR/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Não é útil",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Nota: Se você definir uma pontuação mínima, a pesquisa retornará apenas documentos com pontuação igual ou superior à pontuação mínima.",
 	"Notes": "Notas",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Notificações",

--- a/src/lib/i18n/locales/pt-PT/translation.json
+++ b/src/lib/i18n/locales/pt-PT/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Nota: Se você definir uma pontuação mínima, a pesquisa só retornará documentos com uma pontuação maior ou igual à pontuação mínima.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Notificações da Área de Trabalho",

--- a/src/lib/i18n/locales/ro-RO/translation.json
+++ b/src/lib/i18n/locales/ro-RO/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Nu este de ajutor",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Notă: Dacă setați un scor minim, căutarea va returna doar documente cu un scor mai mare sau egal cu scorul minim.",
 	"Notes": "Note",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Notificări",

--- a/src/lib/i18n/locales/ru-RU/translation.json
+++ b/src/lib/i18n/locales/ru-RU/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Бесполезно",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Обратите внимание: Если вы установите минимальный балл, поиск будет возвращать только документы с баллом больше или равным минимальному баллу.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Уведомления",

--- a/src/lib/i18n/locales/sk-SK/translation.json
+++ b/src/lib/i18n/locales/sk-SK/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Nepomocné",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Poznámka: Ak nastavíte minimálne skóre, vyhľadávanie vráti iba dokumenty s hodnotením, ktoré je väčšie alebo rovné zadanému minimálnemu skóre.",
 	"Notes": "Poznámky",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Oznámenia",

--- a/src/lib/i18n/locales/sr-RS/translation.json
+++ b/src/lib/i18n/locales/sr-RS/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Напомена: ако подесите најмањи резултат, претрага ће вратити само документе са резултатом већим или једнаким најмањем резултату.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Обавештења",

--- a/src/lib/i18n/locales/sv-SE/translation.json
+++ b/src/lib/i18n/locales/sv-SE/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Obs: Om du anger en tröskel kommer sökningen endast att returnera dokument med ett betyg som är större än eller lika med tröskeln.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Notifikationer",

--- a/src/lib/i18n/locales/th-TH/translation.json
+++ b/src/lib/i18n/locales/th-TH/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "หมายเหตุ: หากคุณตั้งค่าคะแนนขั้นต่ำ การค้นหาจะคืนเอกสารที่มีคะแนนมากกว่าหรือเท่ากับคะแนนขั้นต่ำเท่านั้น",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "การแจ้งเตือน",

--- a/src/lib/i18n/locales/tk-TM/translation.json
+++ b/src/lib/i18n/locales/tk-TM/translation.json
@@ -713,4 +713,5 @@
 	"You're offline.": "Offline.",
 	"You've reached your token limit for the day.": "Günüňize token çägiňize ýetdiňiz.",
 	"ZIP Code": "Poçta Kody"
+        "Browser": ""
 }

--- a/src/lib/i18n/locales/tk-TW/translation.json
+++ b/src/lib/i18n/locales/tk-TW/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "",

--- a/src/lib/i18n/locales/tr-TR/translation.json
+++ b/src/lib/i18n/locales/tr-TR/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Yardımcı olmadı",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Not: Minimum bir skor belirlerseniz, arama yalnızca minimum skora eşit veya daha yüksek bir skora sahip belgeleri getirecektir.",
 	"Notes": "Notlar",
+        "Browser": "",
 	"Notification Sound": "Bildirim Sesi",
 	"Notification Webhook": "Bildirim Webhook'u",
 	"Notifications": "Bildirimler",

--- a/src/lib/i18n/locales/uk-UA/translation.json
+++ b/src/lib/i18n/locales/uk-UA/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "Не корисно",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Примітка: Якщо ви встановите мінімальну кількість балів, пошук поверне лише документи з кількістю балів, більшою або рівною мінімальній кількості балів.",
 	"Notes": "Примітки",
+        "Browser": "",
 	"Notification Sound": "Звук сповіщення",
 	"Notification Webhook": "Вебхук для сповіщень",
 	"Notifications": "Сповіщення",

--- a/src/lib/i18n/locales/ur-PK/translation.json
+++ b/src/lib/i18n/locales/ur-PK/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "مددگار نہیں ہے",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "نوٹ: اگر آپ کم از کم سکور سیٹ کرتے ہیں، تو تلاش صرف ان دستاویزات کو واپس کرے گی جن کا سکور کم از کم سکور کے برابر یا اس سے زیادہ ہوگا",
 	"Notes": "نوٹس",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "اطلاعات",

--- a/src/lib/i18n/locales/vi-VN/translation.json
+++ b/src/lib/i18n/locales/vi-VN/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "Lưu ý: Nếu bạn đặt điểm (Score) tối thiểu thì tìm kiếm sẽ chỉ trả về những tài liệu có điểm lớn hơn hoặc bằng điểm tối thiểu.",
 	"Notes": "",
+        "Browser": "",
 	"Notification Sound": "",
 	"Notification Webhook": "",
 	"Notifications": "Thông báo trên máy tính (Notification)",

--- a/src/lib/i18n/locales/zh-CN/translation.json
+++ b/src/lib/i18n/locales/zh-CN/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "无帮助",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "注意：如果设置了最低分数，搜索只会返回分数大于或等于最低分数的文档。",
 	"Notes": "笔记",
+        "Browser": "",
 	"Notification Sound": "通知提示音",
 	"Notification Webhook": "通知 Webhook",
 	"Notifications": "桌面通知",

--- a/src/lib/i18n/locales/zh-TW/translation.json
+++ b/src/lib/i18n/locales/zh-TW/translation.json
@@ -651,6 +651,7 @@
 	"Not helpful": "沒有幫助",
 	"Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.": "注意：如果您設定了最低分數，則搜尋只會回傳分數大於或等於最低分數的文件。",
 	"Notes": "注意",
+        "Browser": "",
 	"Notification Sound": "通知聲音",
 	"Notification Webhook": "通知 Webhook",
 	"Notifications": "通知",

--- a/src/routes/(app)/playground/+layout.svelte
+++ b/src/routes/(app)/playground/+layout.svelte
@@ -50,12 +50,17 @@
 						href="/playground">{$i18n.t('Chat')}</a
 					>
 
-					<!-- <a
-						class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/playground/notes')
-							? ''
-							: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
-						href="/playground/notes">{$i18n.t('Notes')}</a
-					> -->
+                                        <a
+                                                class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/playground/notes')
+                                                        ? ''
+                                                        : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+                                                href="/playground/notes">{$i18n.t('Notes')}</a>
+
+                                        <a
+                                                class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/playground/browser')
+                                                        ? ''
+                                                        : 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+                                                href="/playground/browser">{$i18n.t('Browser')}</a>
 
 					<a
 						class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes(

--- a/src/routes/(app)/playground/browser/+page.svelte
+++ b/src/routes/(app)/playground/browser/+page.svelte
@@ -1,0 +1,9 @@
+<script>
+    import { getContext } from 'svelte';
+    const i18n = getContext('i18n');
+</script>
+
+<div class="p-4 text-center">
+    <h1 class="text-2xl font-semibold">{$i18n.t('Browser')}</h1>
+    <p class="text-gray-500">This is the Browser page.</p>
+</div>


### PR DESCRIPTION
## Summary
- expose `Notes` link in the Playground navigation
- add `Browser` page and show link after Notes
- add empty `Browser` translations for all locales

## Testing
- `npm run lint` *(fails: ESLint config not found)*
- `npm run test:frontend` *(fails: vitest not found)*