### PR TITLE
feat: add central pdf viewer layout

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -82,8 +82,9 @@
 	import Banner from '../common/Banner.svelte';
 	import MessageInput from '$lib/components/chat/MessageInput.svelte';
 	import Messages from '$lib/components/chat/Messages.svelte';
-	import Navbar from '$lib/components/chat/Navbar.svelte';
-	import ChatControls from './ChatControls.svelte';
+        import Navbar from '$lib/components/chat/Navbar.svelte';
+        import ChatControls from './ChatControls.svelte';
+        import PDFViewer from './PDFViewer.svelte';
 	import EventConfirmDialog from '../common/ConfirmDialog.svelte';
 	import Placeholder from './Placeholder.svelte';
 	import NotificationToast from '../NotificationToast.svelte';
@@ -136,9 +137,10 @@
 
 	// Chat Input
 	let prompt = '';
-	let chatFiles = [];
-	let files = [];
-	let params = {};
+        let chatFiles = [];
+        let files = [];
+        let params = {};
+        let selectedFile = null;
 
 	$: if (chatIdProp) {
 		(async () => {
@@ -416,8 +418,9 @@
 		}
 	};
 
-	onMount(async () => {
-		loading = true;
+        onMount(async () => {
+                showControls.set(true);
+                loading = true;
 		console.log('mounted');
 		window.addEventListener('message', onMessageHandler);
 		$socket?.on('chat-events', chatEventHandler);
@@ -2024,8 +2027,8 @@
 			/>
 		{/if}
 
-		<PaneGroup direction="horizontal" class="w-full h-full">
-			<Pane defaultSize={50} class="h-full flex relative max-w-full flex-col">
+                <PaneGroup direction="horizontal" class="w-full h-full">
+                        <Pane defaultSize={25} class="h-full flex relative max-w-full flex-col">
 				<Navbar
 					bind:this={navbarElement}
 					chat={{
@@ -2177,30 +2180,35 @@
 						</div>
 					{/if}
 				</div>
-			</Pane>
+                        </Pane>
+                        <PaneResizer class="w-2 bg-background" />
+                        <Pane defaultSize={50} class="h-full flex">
+                                <PDFViewer file={selectedFile} />
+                        </Pane>
 
-			<ChatControls
-				bind:this={controlPaneComponent}
-				bind:history
-				bind:chatFiles
-				bind:params
-				bind:files
-				bind:pane={controlPane}
-				chatId={$chatId}
-				modelId={selectedModelIds?.at(0) ?? null}
-				models={selectedModelIds.reduce((a, e, i, arr) => {
-					const model = $models.find((m) => m.id === e);
-					if (model) {
-						return [...a, model];
-					}
-					return a;
-				}, [])}
-				{submitPrompt}
-				{stopResponse}
-				{showMessage}
-				{eventTarget}
-			/>
-		</PaneGroup>
+                        <ChatControls
+                                bind:this={controlPaneComponent}
+                                bind:history
+                                bind:chatFiles
+                                bind:params
+                                bind:files
+                                bind:pane={controlPane}
+                                bind:selectedFile
+                                chatId={$chatId}
+                                modelId={selectedModelIds?.at(0) ?? null}
+                                models={selectedModelIds.reduce((a, e, i, arr) => {
+                                        const model = $models.find((m) => m.id === e);
+                                        if (model) {
+                                                return [...a, model];
+                                        }
+                                        return a;
+                                }, [])}
+                                {submitPrompt}
+                                {stopResponse}
+                                {showMessage}
+                                {eventTarget}
+                        />
+                </PaneGroup>
 	{:else if loading}
 		<div class=" flex items-center justify-center h-full w-full">
 			<div class="m-auto">

--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -3,8 +3,9 @@
 	import { slide } from 'svelte/transition';
 	import { Pane, PaneResizer } from 'paneforge';
 
-	import { onDestroy, onMount, tick } from 'svelte';
-	import { mobile, showControls, showCallOverlay, showOverview, showArtifacts } from '$lib/stores';
+        import { onDestroy, onMount, tick } from 'svelte';
+        import { mobile, showControls, showCallOverlay, showOverview, showArtifacts } from '$lib/stores';
+        import { createEventDispatcher } from 'svelte';
 
 	import Modal from '../common/Modal.svelte';
 	import Controls from './Controls/Controls.svelte';
@@ -23,20 +24,23 @@
 	export let chatFiles = [];
 	export let params = {};
 
-	export let eventTarget: EventTarget;
-	export let submitPrompt: Function;
-	export let stopResponse: Function;
-	export let showMessage: Function;
-	export let files;
-	export let modelId;
+        export let eventTarget: EventTarget;
+        export let submitPrompt: Function;
+        export let stopResponse: Function;
+        export let showMessage: Function;
+        export let files;
+        export let modelId;
 
-	export let pane;
+        export let pane;
+        export let selectedFile = null;
+
+        const dispatch = createEventDispatcher();
 
 	let mediaQuery;
 	let largeScreen = false;
 	let dragged = false;
 
-	let minSize = 0;
+        let minSize = 25;
 
 	export const openPane = () => {
 		if (parseInt(localStorage?.chatControlsSize)) {
@@ -178,14 +182,18 @@
 							}}
 						/>
 					{:else}
-						<Controls
-							on:close={() => {
-								showControls.set(false);
-							}}
-							{models}
-							bind:chatFiles
-							bind:params
-						/>
+                                                <Controls
+                                                        on:close={() => {
+                                                                showControls.set(false);
+                                                        }}
+                                                        {models}
+                                                        bind:chatFiles
+                                                        bind:params
+                                                        on:fileselect={(e) => {
+                                                                selectedFile = e.detail;
+                                                                dispatch('fileselect', selectedFile);
+                                                        }}
+                                                />
 					{/if}
 				</div>
 			</Drawer>
@@ -201,10 +209,10 @@
 			</PaneResizer>
 		{/if}
 
-		<Pane
-			bind:pane
-			defaultSize={0}
-			onResize={(size) => {
+                <Pane
+                        bind:pane
+                        defaultSize={25}
+                        onResize={(size) => {
 				console.log('size', size, minSize);
 
 				if ($showControls && pane.isExpanded()) {
@@ -265,18 +273,22 @@
 								}}
 							/>
 						{:else}
-							<Controls
-								on:close={() => {
-									showControls.set(false);
-								}}
-								{models}
-								bind:chatFiles
-								bind:params
-							/>
-						{/if}
-					</div>
-				</div>
-			{/if}
-		</Pane>
+                                                        <Controls
+                                                                on:close={() => {
+                                                                        showControls.set(false);
+                                                                }}
+                                                                {models}
+                                                                bind:chatFiles
+                                                                bind:params
+                                                                on:fileselect={(e) => {
+                                                                        selectedFile = e.detail;
+                                                                        dispatch('fileselect', selectedFile);
+                                                                }}
+                                                        />
+                                                {/if}
+                                        </div>
+                                </div>
+                        {/if}
+                </Pane>
 	{/if}
 </SvelteFlowProvider>

--- a/src/lib/components/chat/Controls/Controls.svelte
+++ b/src/lib/components/chat/Controls/Controls.svelte
@@ -43,20 +43,20 @@
 							name={file.name}
 							type={file.type}
 							size={file?.size}
-							dismissible={true}
-							on:dismiss={() => {
-								// Remove the file from the chatFiles array
+                                                        dismissible={true}
+                                                        on:dismiss={() => {
+                                                                // Remove the file from the chatFiles array
 
-								chatFiles.splice(fileIdx, 1);
-								chatFiles = chatFiles;
-							}}
-							on:click={() => {
-								console.log(file);
-							}}
-						/>
-					{/each}
-				</div>
-			</Collapsible>
+                                                                chatFiles.splice(fileIdx, 1);
+                                                                chatFiles = chatFiles;
+                                                        }}
+                                                        on:click={() => {
+                                                                dispatch('fileselect', file);
+                                                        }}
+                                                />
+                                        {/each}
+                                </div>
+                        </Collapsible>
 
 			<hr class="my-2 border-gray-50 dark:border-gray-700/10" />
 		{/if}

--- a/src/lib/components/chat/PDFViewer.svelte
+++ b/src/lib/components/chat/PDFViewer.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { WEBUI_API_BASE_URL } from '$lib/constants';
+  export let file: any = null;
+  $: isPDF =
+    file &&
+    (file?.meta?.content_type === 'application/pdf' ||
+      file?.name?.toLowerCase().endsWith('.pdf'));
+  $: src = isPDF ? `${WEBUI_API_BASE_URL}/files/${file.id}/content` : null;
+</script>
+
+{#if src}
+  <iframe title={file?.name} src={src} class="w-full h-full border-0" />
+{:else}
+  <div class="w-full h-full flex items-center justify-center text-gray-500">
+    No PDF selected
+  </div>
+{/if}


### PR DESCRIPTION
## Summary
- reorganize chat layout into three panes and show PDF viewer in the center
- wire file selection events from controls to PDF viewer
- default right-side controls pane to 25% width

## Testing
- `npm run lint:frontend` *(fails: ESLint couldn't find config)*
- `npm run test:frontend` *(fails: vitest not found; attempted install but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68934d606be483229f6b56df34c3b31f